### PR TITLE
this should hopefully fix segfaults that can occur when using construction outside of map

### DIFF
--- a/bullet.c
+++ b/bullet.c
@@ -404,8 +404,12 @@ void negative_impact(int X,int Y,int radius)
 	int inner_radius = (radius-BORDER_SIZE)*(radius-BORDER_SIZE);
 	int outer_radius = radius*radius;
 	int BORDER_COLOR = get_border_color();
-	for (x = -radius; x < radius+1; x++)
-		for (y = -radius; y < radius+1; y++)
+	int first_x = -spMin(radius, X);
+	int last_x = spMin(radius, LEVEL_WIDTH-1-X);
+	int first_y = -spMin(radius, Y);
+	int last_y = spMin(radius, LEVEL_HEIGHT-1-Y);
+	for (x = first_x; x <= last_x; x++)
+		for (y = first_y; y <= last_y; y++)
 		{
 			int sum = x*x+y*y;
 			if (sum > outer_radius)


### PR DESCRIPTION
Program received signal SIGSEGV, Segmentation fault.
negative_impact (X=1053, Y=225, radius=241) at bullet.c:415
415                 if (pixel[X+x+(Y+y)*LEVEL_WIDTH] == SP_ALPHA_COLOR)
(gdb) bt
#0  negative_impact (X=1053, Y=225, radius=241) at bullet.c:415
#1  0x000000000041eaca in calc (steps=2571, steps@entry=19) at hase.c:1124
#2  0x00007ffff770d91a in spLoop (spDraw=spDraw@entry=0x4197e0 <draw>,

```
spCalc=spCalc@entry=0x41d580 <calc>, minwait=minwait@entry=10, 
spResize=spResize@entry=0x404760 <resize>, spEvent=spEvent@entry=0x0)
at sparrowCore.c:1205
```
